### PR TITLE
chore: remove unused user repository

### DIFF
--- a/src/apps/api/TeslaStarter.Api/Authentication/DescopeAuthenticationHandler.cs
+++ b/src/apps/api/TeslaStarter.Api/Authentication/DescopeAuthenticationHandler.cs
@@ -3,7 +3,6 @@ using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
 using TeslaStarter.Application.Common.Interfaces;
-using TeslaStarter.Domain.Users;
 
 namespace TeslaStarter.Api.Authentication;
 
@@ -40,7 +39,6 @@ internal sealed class DescopeAuthenticationHandler(
             // Create a scope for resolving scoped services
             using IServiceScope scope = _serviceProvider.CreateScope();
             IDescopeAuthService descopeAuthService = scope.ServiceProvider.GetRequiredService<IDescopeAuthService>();
-            IUserRepository? userRepository = scope.ServiceProvider.GetService<IUserRepository>();
 
             // Validate token and get session result with tenants
             DescopeSessionResult? sessionResult = await descopeAuthService.ValidateSessionAsync(token);


### PR DESCRIPTION
## Summary
- remove unused user repository dependency in DescopeAuthenticationHandler

## Testing
- `dotnet format tesla-starter.sln` *(fails: command not found)*
- `dotnet build tesla-starter.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a14ee545fc832793aa61be23f76d76