### PR TITLE
refactor: simplify user event namespace

### DIFF
--- a/src/services/TeslaStarter.Domain/Users/Events/TeslaAccountLinkedDomainEvent.cs
+++ b/src/services/TeslaStarter.Domain/Users/Events/TeslaAccountLinkedDomainEvent.cs
@@ -1,4 +1,4 @@
-namespace TeslaStarter.Domain.Users.Events;
+namespace TeslaStarter.Domain.Users;
 
 public sealed record TeslaAccountLinkedDomainEvent(
     UserId UserId,

--- a/src/services/TeslaStarter.Domain/Users/Events/TeslaAccountReactivatedDomainEvent.cs
+++ b/src/services/TeslaStarter.Domain/Users/Events/TeslaAccountReactivatedDomainEvent.cs
@@ -1,4 +1,4 @@
-namespace TeslaStarter.Domain.Users.Events;
+namespace TeslaStarter.Domain.Users;
 
 public sealed record TeslaAccountReactivatedDomainEvent(
     UserId UserId,

--- a/src/services/TeslaStarter.Domain/Users/Events/TeslaAccountUnlinkedDomainEvent.cs
+++ b/src/services/TeslaStarter.Domain/Users/Events/TeslaAccountUnlinkedDomainEvent.cs
@@ -1,4 +1,4 @@
-namespace TeslaStarter.Domain.Users.Events;
+namespace TeslaStarter.Domain.Users;
 
 public sealed record TeslaAccountUnlinkedDomainEvent(
     UserId UserId,

--- a/src/services/TeslaStarter.Domain/Users/Events/UserCreatedDomainEvent.cs
+++ b/src/services/TeslaStarter.Domain/Users/Events/UserCreatedDomainEvent.cs
@@ -1,4 +1,4 @@
-namespace TeslaStarter.Domain.Users.Events;
+namespace TeslaStarter.Domain.Users;
 
 public sealed record UserCreatedDomainEvent(
     UserId UserId,

--- a/src/services/TeslaStarter.Domain/Users/Events/UserLoggedInDomainEvent.cs
+++ b/src/services/TeslaStarter.Domain/Users/Events/UserLoggedInDomainEvent.cs
@@ -1,4 +1,4 @@
-namespace TeslaStarter.Domain.Users.Events;
+namespace TeslaStarter.Domain.Users;
 
 public sealed record UserLoggedInDomainEvent(
     UserId UserId,

--- a/src/services/TeslaStarter.Domain/Users/Events/UserProfileUpdatedDomainEvent.cs
+++ b/src/services/TeslaStarter.Domain/Users/Events/UserProfileUpdatedDomainEvent.cs
@@ -1,4 +1,4 @@
-namespace TeslaStarter.Domain.Users.Events;
+namespace TeslaStarter.Domain.Users;
 
 public sealed record UserProfileUpdatedDomainEvent(
     UserId UserId,

--- a/src/services/TeslaStarter.Domain/Users/User.cs
+++ b/src/services/TeslaStarter.Domain/Users/User.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using Common.Domain.Base;
-using TeslaStarter.Domain.Users.Events;
 
 namespace TeslaStarter.Domain.Users;
 

--- a/tests/services/TeslaStarter.Domain.Tests/GlobalUsings.cs
+++ b/tests/services/TeslaStarter.Domain.Tests/GlobalUsings.cs
@@ -1,7 +1,6 @@
 global using Common.Domain.ValueObjects;
 global using FluentAssertions;
 global using TeslaStarter.Domain.Users;
-global using TeslaStarter.Domain.Users.Events;
 global using TeslaStarter.Domain.Vehicles;
 global using TeslaStarter.Domain.Vehicles.Events;
 global using Xunit;

--- a/tests/services/TeslaStarter.Infrastructure.Tests/Persistence/UnitOfWorkTests.cs
+++ b/tests/services/TeslaStarter.Infrastructure.Tests/Persistence/UnitOfWorkTests.cs
@@ -4,7 +4,6 @@ using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using TeslaStarter.Domain.Users;
-using TeslaStarter.Domain.Users.Events;
 using TeslaStarter.Infrastructure.Persistence;
 using Xunit;
 


### PR DESCRIPTION
## Summary
- move user domain events into TeslaStarter.Domain.Users namespace
- update usings after namespace change

## Testing
- `dotnet format tesla-starter.sln` *(fails: command not found)*
- `dotnet build tesla-starter.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a14eeaf7148327a6b1245d029afb90