### PR TITLE
refactor: deserialize Tesla token responses via DTO

### DIFF
--- a/src/services/TeslaStarter.Infrastructure/Authentication/TeslaOAuthService.cs
+++ b/src/services/TeslaStarter.Infrastructure/Authentication/TeslaOAuthService.cs
@@ -19,6 +19,7 @@ public class TeslaOAuthService(
     private readonly ILogger<TeslaOAuthService> _logger = logger;
 
     private const string TeslaAuthBaseUrl = "https://fleet-auth.prd.vn.cloud.tesla.com";
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
     public string GenerateAuthorizationUrl(string state)
     {
@@ -61,18 +62,18 @@ public class TeslaOAuthService(
             }
 
             string json = await response.Content.ReadAsStringAsync();
-            Dictionary<string, JsonElement>? tokenResponse = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+            TeslaTokenDto? dto = JsonSerializer.Deserialize<TeslaTokenDto>(json, JsonOptions);
 
-            if (tokenResponse == null)
+            if (dto == null)
                 return null;
 
             return new TeslaTokenResponse
             {
-                AccessToken = tokenResponse.GetValueOrDefault("access_token").GetString() ?? "",
-                RefreshToken = tokenResponse.GetValueOrDefault("refresh_token").GetString() ?? "",
-                IdToken = tokenResponse.GetValueOrDefault("id_token").GetString() ?? "",
-                TokenType = tokenResponse.GetValueOrDefault("token_type").GetString() ?? "Bearer",
-                ExpiresIn = tokenResponse.GetValueOrDefault("expires_in").TryGetInt32(out int exp) ? exp : 3600
+                AccessToken = dto.AccessToken ?? "",
+                RefreshToken = dto.RefreshToken ?? "",
+                IdToken = dto.IdToken ?? "",
+                TokenType = dto.TokenType ?? "Bearer",
+                ExpiresIn = dto.ExpiresIn ?? 3600
             };
         }
         catch (Exception ex)
@@ -110,18 +111,18 @@ public class TeslaOAuthService(
             }
 
             string json = await response.Content.ReadAsStringAsync();
-            Dictionary<string, JsonElement>? tokenResponse = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+            TeslaTokenDto? dto = JsonSerializer.Deserialize<TeslaTokenDto>(json, JsonOptions);
 
-            if (tokenResponse == null)
+            if (dto == null)
                 return null;
 
             return new TeslaTokenResponse
             {
-                AccessToken = tokenResponse.GetValueOrDefault("access_token").GetString() ?? "",
-                RefreshToken = tokenResponse.GetValueOrDefault("refresh_token").GetString() ?? "",
-                IdToken = tokenResponse.GetValueOrDefault("id_token").GetString() ?? "",
-                TokenType = tokenResponse.GetValueOrDefault("token_type").GetString() ?? "Bearer",
-                ExpiresIn = tokenResponse.GetValueOrDefault("expires_in").TryGetInt32(out int exp) ? exp : 3600
+                AccessToken = dto.AccessToken ?? "",
+                RefreshToken = dto.RefreshToken ?? "",
+                IdToken = dto.IdToken ?? "",
+                TokenType = dto.TokenType ?? "Bearer",
+                ExpiresIn = dto.ExpiresIn ?? 3600
             };
         }
         catch (Exception ex)

--- a/src/services/TeslaStarter.Infrastructure/Authentication/TeslaTokenDto.cs
+++ b/src/services/TeslaStarter.Infrastructure/Authentication/TeslaTokenDto.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace TeslaStarter.Infrastructure.Authentication;
+
+internal sealed class TeslaTokenDto
+{
+    [JsonPropertyName("access_token")]
+    public string? AccessToken { get; set; }
+
+    [JsonPropertyName("refresh_token")]
+    public string? RefreshToken { get; set; }
+
+    [JsonPropertyName("id_token")]
+    public string? IdToken { get; set; }
+
+    [JsonPropertyName("token_type")]
+    public string? TokenType { get; set; }
+
+    [JsonPropertyName("expires_in")]
+    public int? ExpiresIn { get; set; }
+}
+


### PR DESCRIPTION
## Summary
- parse OAuth token responses into a dedicated TeslaTokenDto
- map token DTO to existing TeslaTokenResponse model

## Testing
- `dotnet format --no-restore` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a14ee993608327aa4f3cf2d3b2b594