### PR TITLE
feat(api): add descope user id extension

### DIFF
--- a/src/apps/api/TeslaStarter.Api/Controllers/AuthController.cs
+++ b/src/apps/api/TeslaStarter.Api/Controllers/AuthController.cs
@@ -14,6 +14,7 @@ using TeslaStarter.Application.Vehicles.DTOs;
 using TeslaStarter.Application.Vehicles.Queries.GetVehiclesByTeslaAccount;
 using TeslaStarter.Domain.Users;
 using TeslaStarter.Infrastructure.Authentication;
+using TeslaStarter.Api.Extensions;
 
 namespace TeslaStarter.Api.Controllers;
 
@@ -37,7 +38,7 @@ public class AuthController(
     [Authorize]
     public async Task<IActionResult> GetCurrentUser()
     {
-        string? descopeUserId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        string? descopeUserId = User.GetDescopeUserId();
         if (string.IsNullOrEmpty(descopeUserId))
             return Unauthorized();
 
@@ -67,7 +68,7 @@ public class AuthController(
     [Authorize]
     public IActionResult InitiateTeslaAuth()
     {
-        string? descopeUserId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        string? descopeUserId = User.GetDescopeUserId();
         if (string.IsNullOrEmpty(descopeUserId))
             return Unauthorized();
 
@@ -96,7 +97,7 @@ public class AuthController(
     [Authorize]
     public async Task<IActionResult> HandleTeslaCallback([FromBody] TeslaCallbackRequest request)
     {
-        string? descopeUserId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        string? descopeUserId = User.GetDescopeUserId();
         if (string.IsNullOrEmpty(descopeUserId))
             return Unauthorized();
 
@@ -175,7 +176,7 @@ public class AuthController(
     [Authorize]
     public async Task<IActionResult> RefreshTeslaTokens()
     {
-        string? descopeUserId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        string? descopeUserId = User.GetDescopeUserId();
         if (string.IsNullOrEmpty(descopeUserId))
             return Unauthorized();
 
@@ -220,7 +221,7 @@ public class AuthController(
     [Authorize]
     public async Task<IActionResult> UnlinkTeslaAccount()
     {
-        string? descopeUserId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        string? descopeUserId = User.GetDescopeUserId();
         if (string.IsNullOrEmpty(descopeUserId))
             return Unauthorized();
 
@@ -269,7 +270,7 @@ public class AuthController(
     [Authorize]
     public async Task<IActionResult> GetMyVehicles()
     {
-        string? descopeUserId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        string? descopeUserId = User.GetDescopeUserId();
         if (string.IsNullOrEmpty(descopeUserId))
             return Unauthorized();
 
@@ -295,7 +296,7 @@ public class AuthController(
     [Authorize]
     public async Task<IActionResult> SyncVehicles()
     {
-        string? descopeUserId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        string? descopeUserId = User.GetDescopeUserId();
         if (string.IsNullOrEmpty(descopeUserId))
             return Unauthorized();
 

--- a/src/apps/api/TeslaStarter.Api/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/apps/api/TeslaStarter.Api/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,10 @@
+using System.Security.Claims;
+
+namespace TeslaStarter.Api.Extensions;
+
+public static class ClaimsPrincipalExtensions
+{
+    public static string? GetDescopeUserId(this ClaimsPrincipal user)
+        => user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+}
+


### PR DESCRIPTION
## Summary
- add `GetDescopeUserId` extension for `ClaimsPrincipal`
- replace repeated claim lookups in `AuthController`

## Testing
- `dotnet format` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*
- `pnpm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a14ee864fc832785cd44d86fd36a76